### PR TITLE
Update HTTP API documentation for tool routing

### DIFF
--- a/docs/MCP_SERVER_GUIDE.md
+++ b/docs/MCP_SERVER_GUIDE.md
@@ -263,20 +263,31 @@ make db-upgrade-docker
 ```
 
 ### **Direct HTTP API**
-All tools are also available as direct HTTP endpoints:
+Each tool is exposed over HTTP as `POST /tool/{name}`, using the same argument schema described in the [JSON-RPC `tools/call` example](#mcp-json-rpc-protocol) above.
+
 ```bash
 # Add memory
-curl -X POST http://127.0.0.1:8081/add_memory \
+curl -X POST http://127.0.0.1:8081/tool/add_memory \
   -H "Authorization: Bearer $MCP_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"content": "Memory content", "tags": ["tag1"]}'
+  -d '{
+        "projectId": "neural-forge",
+        "content": "Memory content",
+        "metadata": {"tags": ["tag1"]}
+      }'
 
 # Search memories
-curl -X POST http://127.0.0.1:8081/search_memory \
+curl -X POST http://127.0.0.1:8081/tool/search_memory \
   -H "Authorization: Bearer $MCP_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"query": "search terms", "limit": 10}'
+  -d '{
+        "projectId": "neural-forge",
+        "query": "search terms",
+        "limit": 10
+      }'
 ```
+
+All individual tool routes are multiplexed through `/tool/{name}`, so the server dispatches the request based on the tool name just like it does for [`tools/call`](#mcp-json-rpc-protocol) over JSON-RPC.
 
 #### Admin Endpoints (Diagnostics)
 


### PR DESCRIPTION
## Summary
- update the direct HTTP API examples to use the POST /tool/{name} endpoint with the required authorization header
- explain that the server multiplexes individual tool routes through /tool/{name} and reference the JSON-RPC usage example for consistency
- verify the documentation no longer references legacy /add_memory or /search_memory paths

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68d4117921748328ad3e334a183ec5d5